### PR TITLE
Add functionality so messages do not repeat until all messages have been viewed

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,13 +43,13 @@ function sayingAndDisplaying(event) {
       if (messageSelect[i].value === "radio-left") {
          messageReturn.innerHTML = `<p class="message-align">${getRandomPhrase(affirmations)}</p>`;
          takeFromPhrasesAndGiveToViewedPhrases(affirmations, previouslyViewedAffirmations);
-         resetPhrases(affirmations, previouslyViewedAffirmations);
-         console.log(affirmations, previouslyViewedAffirmations);
-      } else if (messageSelect[i].value === "radio-right") {
+        // resetPhrases(affirmations, previouslyViewedAffirmations);
+         console.log(affirmations.length, previouslyViewedAffirmations);
+       } else if (messageSelect[i].value === "radio-right") {
          messageReturn.innerHTML = `<p class="message-align">${getRandomPhrase(mantras)}</p>`;
          takeFromPhrasesAndGiveToViewedPhrases(mantras, previouslyViewedMantras);
-         resetPhrases(mantras, previouslyViewedMantras);
-         console.log(mantras, previouslyViewedMantras);
+        // resetPhrases(mantras, previouslyViewedMantras);
+         console.log(mantras.length, previouslyViewedMantras);
       }
     }
   }
@@ -59,19 +59,26 @@ function takeFromPhrasesAndGiveToViewedPhrases(phrases, viewedPhrases) {
   if (phrases.includes(messageToBeViewed)) {
     viewedPhrases.push(messageToBeViewed);
     phrases.splice(phrases.indexOf(messageToBeViewed), 1);
+    if (!phrases.length) {
+      for (var i = 0; i < viewedPhrases.length; i++) {
+        phrases.push(viewedPhrases[i]);
+      }
+      viewedPhrases.splice(0);
+      // also as part of this conditional, an alert should be displayed as such: `Your ${phrases} will now begin to repeat`
+    }
   }
 }
 
 //arguments to be passed in the function call below would be mantras and previouslyViewedMantras,
 //or affirmations and previouslyViewedAffirmations
-function resetPhrases(phrases, viewedPhrases) {
-  if (phrases.length === 0) {
-    phrases = viewedPhrases;
-  }
-}
+// function resetPhrases(phrases, viewedPhrases) {
+//   if (phrases.length === 0) {
+//     phrases = viewedPhrases;
+//   }
+//}
 
-function getRandomIndex(array) {
-  return Math.floor(Math.random() * array.length);
+function getRandomIndex(phrase) {
+  return Math.floor(Math.random() * phrase.length);
 }
 
 function getRandomPhrase(sayings) {


### PR DESCRIPTION
Functionality has been implemented so the user never sees a repeating affirmation until all affirmations have been viewed, and the same goes for the mantras. It is functional, but I'm sure I can refactor and "Dry" up the code a bit. Next step is to set up a window alert to let the user know they have seem all of the messages and they will begin to repeat.